### PR TITLE
Fix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ If you would like to try the 'instruction-response' mode using the fine-tuned we
 **7. Download the fine-tuned weights**
 
 ```bash
-python3 alpaca-lora/export_state_dict_checkpoint.py
+cd alpaca-lora
+python3 export_state_dict_checkpoint.py
+cd ..
 python3 clean_hf_cache.py
 ```
 


### PR DESCRIPTION
You need to run the export_state_dict_checkpoint.py in alpaca-lora directory, because it creates the ckpt dir in the current working directory and that's when the next command (chat.py) expects it.